### PR TITLE
Fix for jodatime IllegalInstantException: Cannot parse.. Illegal inst…

### DIFF
--- a/app/src/main/java/com/urbandroid/sleep/addon/stats/model/socialjetlag/SleepRegularityIndexUtil.java
+++ b/app/src/main/java/com/urbandroid/sleep/addon/stats/model/socialjetlag/SleepRegularityIndexUtil.java
@@ -14,6 +14,9 @@ import org.apache.commons.math3.util.Pair;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
+import org.joda.time.LocalDate;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -29,6 +32,7 @@ import java.util.TreeMap;
 
 public class SleepRegularityIndexUtil {
 
+    private final static String DATE_PATTERN = "yyyy-MM-dd";
     /**
      * Splits a date that over flows to the next day into two intervals
      * @param startTime StartTime of an interval that overflows
@@ -37,11 +41,11 @@ public class SleepRegularityIndexUtil {
      */
     protected Interval[] splitOverFlowingDate(DateTime startTime, DateTime endTime){
         DateTime firstIntervalEndTime = new DateTime(
-                startTime.year().get(), startTime.monthOfYear().get(), startTime.dayOfMonth().get(), 23, 59
+                startTime.year().get(), startTime.monthOfYear().get(), startTime.dayOfMonth().get(), 23, 59, 59, 999
         ).withZoneRetainFields(DateTimeZone.UTC);
 
         DateTime secondIntervalStartTime = new DateTime(
-                endTime.year().get(), endTime.monthOfYear().get(), endTime.dayOfMonth().get(), 00, 00
+                endTime.year().get(), endTime.monthOfYear().get(), endTime.dayOfMonth().get(), 0, 0, 0, 0
         ).withZoneRetainFields(DateTimeZone.UTC);
 
         return new Interval[] {new Interval(startTime, firstIntervalEndTime), new Interval(secondIntervalStartTime, endTime)};
@@ -109,7 +113,7 @@ public class SleepRegularityIndexUtil {
             BitSet sleepState;
 
             DateTime awakeIntervalStartTime = awakeInterval.getStart();
-            String awakeIntervalFrom = awakeIntervalStartTime.toString("yyyy-MM-dd");
+            String awakeIntervalFrom = awakeIntervalStartTime.toString(DATE_PATTERN);
 
             if(sleepStateByDateMap.containsKey(awakeIntervalFrom)){
                 sleepState = sleepStateByDateMap.get(awakeIntervalFrom);
@@ -166,8 +170,10 @@ public class SleepRegularityIndexUtil {
 
                 String prevDateKey = (String) prevDayIt.next();
                 String nextDateKey =  (String) nextDayIt.next();
-                DateTime prevDate = new DateTime(prevDateKey);
-                DateTime nextDate = new DateTime(nextDateKey);
+
+                DateTimeFormatter formatter = DateTimeFormat.forPattern(DATE_PATTERN);
+                DateTime prevDate = DateTime.parse(prevDateKey, formatter);
+                DateTime nextDate = DateTime.parse(nextDateKey, formatter);
 
                 if(isNextDate(prevDate, nextDate)){ // if there are a continuous pair of days, calculate the SRI
 
@@ -187,7 +193,7 @@ public class SleepRegularityIndexUtil {
                     }
                 } else { // Dates are no longer continuous, make a new group
                     groupNum++;
-                    System.out.println("Skipping SRI score calculation for following pair of dates. Date ranges must be contiguous to compute the SRI. User provided date ranges: " + prevDateKey + "- " + nextDateKey);
+                    Logger.logSevere("Skipping SRI score calculation for following pair of dates. Date ranges must be contiguous to compute the SRI. User provided date ranges: " + prevDateKey + "- " + nextDateKey);
                 }
             }
         }
@@ -230,7 +236,7 @@ public class SleepRegularityIndexUtil {
     protected float calculateAverageMSRI(TreeMap<String, BitSet> sleepStateByDateMap){
         Set keys = sleepStateByDateMap.keySet();
 
-        if (keys.size() < 3){ // there should be at least three dates to calculate the mSRI
+        if (keys.size() < 3) { // there should be at least three dates to calculate the mSRI
             return -1.0f;
         }
 
@@ -264,9 +270,13 @@ public class SleepRegularityIndexUtil {
     }
 
     public float getSleepIrregularity(ChronoRecords records) {
+
+
         List<Interval> awakeTimes = convertChronoRecordsToTimeIntervals(records);
         TreeMap<String, BitSet> sleepStateByDateMap = createSleepStateByDateMap(awakeTimes);
 
-        return calculateAverageSRI(sleepStateByDateMap);
+        float result = calculateAverageSRI(sleepStateByDateMap);
+//        Logger.logSevere("REGULARITY SRI records " + records.getFrom() + " - " + records.getTo() + " = " + result);
+        return result;
     }
 }


### PR DESCRIPTION
…ant due to time zone offset transition

org.joda.time.IllegalInstantException: Cannot parse "2023-09-03": Illegal instant due to time zone offset transition (America/Santiago)
	org.joda.time.format.DateTimeParserBucket.computeMillis(SourceFile:390)
	org.joda.time.format.DateTimeFormatter.parseMillis(SourceFile:749)
	org.joda.time.convert.StringConverter.getInstantMillis(SourceFile:65)
	org.joda.time.base.BaseDateTime.<init>(SourceFile:171)
	org.joda.time.DateTime.<init>(SourceFile:241)
	com.urbandroid.sleep.addon.stats.model.socialjetlag.SleepRegularityIndexUtil.extractSRIScores(SourceFile:172)